### PR TITLE
fix: CBP-4135: run action container as root again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM gcr.io/distroless/static:nonroot
-
 COPY bin/cbhelmpkg /
-
+USER root:root
 ENTRYPOINT ["/cbhelmpkg"]


### PR DESCRIPTION
This is because a customer reported that a workflow broke when we changed the Action to using a non-root user and because other Actions such as e.g. the `configure-ecr-credentials` Action write credentials as root user with user-only read permissions into the shared home directory.

This is a follow-up of #4