### PR TITLE
[CBP-41475] Upgrade Go to 1.26.2 for CVE-2026-27143

### DIFF
--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -25,7 +25,7 @@ jobs:
           exit 1
         fi
     - name: Build binary
-      uses: docker://golang:1.26.0-alpine3.22
+      uses: docker://golang:1.26.2-alpine3.22
       run: go build -a -ldflags '-w -s -extldflags \"-static\"' -o ./bin/cbhelmpkg ./cmd/cbhelmpkg
       env:
         CGO_ENABLED: "0"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudbees-io/helm-package
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/cloudbees-io/registry-config v0.0.0-20240808192011-86b0b147c63e


### PR DESCRIPTION
CBP-41475: Upgrade Go to 1.26.2 for CVE-2026-27143